### PR TITLE
Add CloudWatch inactivity alarm to shut down server

### DIFF
--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -1,0 +1,17 @@
+resource "aws_cloudwatch_metric_alarm" "inactivity" {
+  alarm_name          = "minecraft-inactivity"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  statistic           = "Average"
+  threshold           = 5
+  period              = 300
+
+  dimensions = {
+    InstanceId = aws_instance.minecraft.id
+  }
+
+  alarm_description = "Monitors the Minecraft server for inactivity"
+  alarm_actions       = ["arn:aws:automate:us-east-1:ec2:stop"]
+}


### PR DESCRIPTION
- Server stops after 10 minutes of <5% CPU utilization