### PR TITLE
Robust inactivity alarm

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -3,7 +3,7 @@ resource "aws_apigatewayv2_domain_name" "domain" {
 
   domain_name_configuration {
     certificate_arn = local.ssl_cert_arn
-    endpoint_type   = "REGIONAL"
+    endpoint_type = "REGIONAL"
     security_policy = "TLS_1_2"
   }
 }
@@ -21,7 +21,7 @@ resource "aws_apigatewayv2_api" "minecraft" {
 
 resource "aws_apigatewayv2_stage" "stage" {
   api_id = aws_apigatewayv2_api.minecraft.id
-  name   = "$default"
+  name = "$default"
   auto_deploy = true
 }
 
@@ -40,10 +40,10 @@ resource "aws_apigatewayv2_integration" "start" {
 }
 
 resource "aws_lambda_permission" "start_permission" {
-  statement_id  = "AllowStartInvoke"
-  action        = "lambda:InvokeFunction"
+  statement_id = "AllowStartInvoke"
+  action = "lambda:InvokeFunction"
   function_name = "start"
-  principal     = "apigateway.amazonaws.com"
+  principal = "apigateway.amazonaws.com"
   source_arn = "${aws_apigatewayv2_api.minecraft.execution_arn}/*/*/start"
 }
 
@@ -62,9 +62,9 @@ resource "aws_apigatewayv2_integration" "stop" {
 }
 
 resource "aws_lambda_permission" "stop_permission" {
-  statement_id  = "AllowStopInvoke"
-  action        = "lambda:InvokeFunction"
+  statement_id = "AllowStopInvoke"
+  action = "lambda:InvokeFunction"
   function_name = "stop"
-  principal     = "apigateway.amazonaws.com"
+  principal = "apigateway.amazonaws.com"
   source_arn = "${aws_apigatewayv2_api.minecraft.execution_arn}/*/*/stop"
 }

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -8,7 +8,6 @@ resource "aws_cloudwatch_metric_alarm" "inactivity" {
   threshold = 5
   period = 300
   treat_missing_data = "notBreaching"
-  evaluate_low_sample_count_percentiles = "ignore"
 
   dimensions = {
     InstanceId = aws_instance.minecraft.id

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -1,12 +1,12 @@
 resource "aws_cloudwatch_metric_alarm" "inactivity" {
-  alarm_name          = "minecraft-inactivity"
+  alarm_name = "minecraft-inactivity"
   comparison_operator = "LessThanThreshold"
-  evaluation_periods  = 2
-  metric_name         = "CPUUtilization"
-  namespace           = "AWS/EC2"
-  statistic           = "Average"
-  threshold           = 5
-  period              = 300
+  evaluation_periods = 2
+  metric_name = "CPUUtilization"
+  namespace = "AWS/EC2"
+  statistic = "Average"
+  threshold = 5
+  period = 300
   treat_missing_data = "notBreaching"
   evaluate_low_sample_count_percentiles = "ignore"
 
@@ -15,5 +15,5 @@ resource "aws_cloudwatch_metric_alarm" "inactivity" {
   }
 
   alarm_description = "Monitors the Minecraft server for inactivity"
-  alarm_actions       = ["arn:aws:automate:us-east-1:ec2:stop"]
+  alarm_actions = ["arn:aws:automate:us-east-1:ec2:stop"]
 }

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -5,7 +5,7 @@ resource "aws_cloudwatch_metric_alarm" "inactivity" {
   metric_name = "CPUUtilization"
   namespace = "AWS/EC2"
   statistic = "Average"
-  threshold = 5
+  threshold = 2
   period = 300
   treat_missing_data = "notBreaching"
 

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -7,6 +7,8 @@ resource "aws_cloudwatch_metric_alarm" "inactivity" {
   statistic           = "Average"
   threshold           = 5
   period              = 300
+  treat_missing_data = "notBreaching"
+  evaluate_low_sample_count_percentiles = "ignore"
 
   dimensions = {
     InstanceId = aws_instance.minecraft.id

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -16,9 +16,9 @@ resource "aws_security_group" "minecraft" {
 
   # Outbound internet access
   egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
+    from_port = 0
+    to_port = 0
+    protocol = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
 

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -4,16 +4,16 @@ locals {
 }
 
 data "archive_file" "init" {
-  type        = "zip"
+  type = "zip"
   source_file = local.lambda_source
   output_path = local.lambda_build
 }
 
 resource "aws_lambda_function" "start" {
-  filename      = local.lambda_build
+  filename = local.lambda_build
   function_name = "start"
-  role          = aws_iam_role.role.arn
-  handler       = "handlers.start"
+  role = aws_iam_role.role.arn
+  handler = "handlers.start"
   source_code_hash = filebase64sha256(local.lambda_build)
   runtime = "nodejs12.x"
   environment {
@@ -24,10 +24,10 @@ resource "aws_lambda_function" "start" {
 }
 
 resource "aws_lambda_function" "stop" {
-  filename      = local.lambda_build
+  filename = local.lambda_build
   function_name = "stop"
-  role          = aws_iam_role.role.arn
-  handler       = "handlers.stop"
+  role = aws_iam_role.role.arn
+  handler = "handlers.stop"
   source_code_hash = filebase64sha256(local.lambda_build)
   runtime = "nodejs12.x"
   environment {
@@ -56,7 +56,7 @@ EOF
 }
 
 resource "aws_iam_policy" "logging_ec2" {
-  name        = "lambda_logging"
+  name = "lambda_logging"
   description = "IAM policy for logging from a lambda"
 
   policy = <<EOF
@@ -86,6 +86,6 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_logs" {
-  role       = aws_iam_role.role.name
+  role = aws_iam_role.role.name
   policy_arn = aws_iam_policy.logging_ec2.arn
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
   version = "~> 2.59"
   profile = "default"
-  region  = "us-east-1"
+  region = "us-east-1"
 }

--- a/terraform/private.tf.example
+++ b/terraform/private.tf.example
@@ -6,12 +6,12 @@ locals {
 terraform {
   backend "s3" {
     bucket = "example-bucket"
-    key    = "terraform.tfstate"
+    key = "terraform.tfstate"
     region = "us-east-1"
   }
 }
 
 resource "aws_key_pair" "minecraft" {
-  key_name   = "minecraft"
+  key_name = "minecraft"
   public_key = "ssh-rsa foobarbazfizzbuzzquixquux"
 }


### PR DESCRIPTION
- Reduce alarm threshold from 5% CPU utilization to 2%
- Use "missing data" as good (not in violation of alarm threshold). We want the alarm to tell us when there's:
  - a server running
  - no CPU utilization

This should reduce the occurrence of inadvertent shutdowns before players can connect. If we ignore missing data, then previous 0% utilization measurements (prior to shutdown) would be used at server start time, so there was a decent chance the server would quickly be in alarm state and shut down.