### PR TITLE
Increase alarm evaluation

### DIFF
--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudwatch_metric_alarm" "inactivity" {
   alarm_name = "minecraft-inactivity"
   comparison_operator = "LessThanThreshold"
-  evaluation_periods = 2
+  evaluation_periods = 3
   metric_name = "CPUUtilization"
   namespace = "AWS/EC2"
   statistic = "Average"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.59"
+  version = "~> 2.60"
   profile = "default"
   region = "us-east-1"
 }


### PR DESCRIPTION
- Increase number of evaluation periods of the inactivity alarm from 2 to 3

I've been getting reports that the server can be flaky on startup... players start the server, connect, only to be kicked seconds later because the server shut down due to inactivity. This is especially problematic because if the player again starts the server, the dynamic DNS will refuse another update within a 5 minute period.

I haven't found documentation describing the exact timing of CloudWatch metrics, but I find it strange that an alarm based on 2 evaluation periods can trigger well within the time of a single 300s period. Example:
```
Lambda log: 21:38:10 [redacted server URL]/start was invoked
ddclient log: 21:38:31 SUCCESS: IP address set to [redacted IP address]
Minecraft log: 21:41:04 Player connected: [redacted player name], xuid: [redacted player id]
CloudWatch event log: 21:41:20 Alarm updated from OK to In alarm
Minecraft log: 21:41:21 Stopping Minecraft Service...
```
The CloudWatch metric plot shows samples taken at 21:35:00 and 21:40:00.

Anyway, until I better understand, I'll simply extend the evaluation to 3 periods. I have to imagine this won't turn off the server within 5 minutes... right?!