### PR TITLE
Server Start Notifications

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -25,68 +25,25 @@ resource "aws_apigatewayv2_stage" "stage" {
   auto_deploy = true
 }
 
-resource "aws_apigatewayv2_route" "start" {
-  api_id = aws_apigatewayv2_api.minecraft.id
-  route_key = "GET /start"
-  target = "integrations/${aws_apigatewayv2_integration.start.id}"
+module "start" {
+  source = "./route"
+  name = "start"
+  api = aws_apigatewayv2_api.minecraft
+  ec2_instance = aws_instance.minecraft
+  sns_topic_arn = aws_sns_topic.server_start.arn
+  sns_message = "The server has been started!"
 }
 
-resource "aws_apigatewayv2_integration" "start" {
-  api_id = aws_apigatewayv2_api.minecraft.id
-  integration_type = "AWS_PROXY"
-  integration_method = "POST"
-  integration_uri = aws_lambda_function.start.invoke_arn
-  payload_format_version = "2.0"
+module "stop" {
+  source = "./route"
+  name = "stop"
+  api = aws_apigatewayv2_api.minecraft
+  ec2_instance = aws_instance.minecraft
 }
 
-resource "aws_lambda_permission" "start_permission" {
-  statement_id = "AllowStartInvoke"
-  action = "lambda:InvokeFunction"
-  function_name = "start"
-  principal = "apigateway.amazonaws.com"
-  source_arn = "${aws_apigatewayv2_api.minecraft.execution_arn}/*/*/start"
-}
-
-resource "aws_apigatewayv2_route" "stop" {
-  api_id = aws_apigatewayv2_api.minecraft.id
-  route_key = "GET /stop"
-  target = "integrations/${aws_apigatewayv2_integration.stop.id}"
-}
-
-resource "aws_apigatewayv2_integration" "stop" {
-  api_id = aws_apigatewayv2_api.minecraft.id
-  integration_type = "AWS_PROXY"
-  integration_method = "POST"
-  integration_uri = aws_lambda_function.stop.invoke_arn
-  payload_format_version = "2.0"
-}
-
-resource "aws_lambda_permission" "stop_permission" {
-  statement_id = "AllowStopInvoke"
-  action = "lambda:InvokeFunction"
-  function_name = "stop"
-  principal = "apigateway.amazonaws.com"
-  source_arn = "${aws_apigatewayv2_api.minecraft.execution_arn}/*/*/stop"
-}
-
-resource "aws_apigatewayv2_route" "status" {
-  api_id = aws_apigatewayv2_api.minecraft.id
-  route_key = "GET /status"
-  target = "integrations/${aws_apigatewayv2_integration.status.id}"
-}
-
-resource "aws_apigatewayv2_integration" "status" {
-  api_id = aws_apigatewayv2_api.minecraft.id
-  integration_type = "AWS_PROXY"
-  integration_method = "POST"
-  integration_uri = aws_lambda_function.status.invoke_arn
-  payload_format_version = "2.0"
-}
-
-resource "aws_lambda_permission" "status_permission" {
-  statement_id = "AllowStatusInvoke"
-  action = "lambda:InvokeFunction"
-  function_name = "status"
-  principal = "apigateway.amazonaws.com"
-  source_arn = "${aws_apigatewayv2_api.minecraft.execution_arn}/*/*/status"
+module "status" {
+  source = "./route"
+  name = "status"
+  api = aws_apigatewayv2_api.minecraft
+  ec2_instance = aws_instance.minecraft
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.60"
+  version = "~> 2.68"
   profile = "default"
   region = "us-east-1"
 }

--- a/terraform/route/integration.tf
+++ b/terraform/route/integration.tf
@@ -1,0 +1,21 @@
+resource "aws_apigatewayv2_route" "route" {
+  api_id = var.api.id
+  route_key = "GET /${var.name}"
+  target = "integrations/${aws_apigatewayv2_integration.integration.id}"
+}
+
+resource "aws_apigatewayv2_integration" "integration" {
+  api_id = var.api.id
+  integration_type = "AWS_PROXY"
+  integration_method = "POST"
+  integration_uri = aws_lambda_function.lambda.invoke_arn
+  payload_format_version = "2.0"
+}
+
+resource "aws_lambda_permission" "permission" {
+  statement_id = "Allow${var.name}Invoke"
+  action = "lambda:InvokeFunction"
+  function_name = var.name
+  principal = "apigateway.amazonaws.com"
+  source_arn = "${var.api.execution_arn}/*/*/${var.name}"
+}

--- a/terraform/route/variables.tf
+++ b/terraform/route/variables.tf
@@ -1,0 +1,5 @@
+variable "name" {}
+variable "api" {}
+variable "ec2_instance" {}
+variable "sns_topic_arn" { default = null }
+variable "sns_message" { default = null }

--- a/terraform/sns.tf
+++ b/terraform/sns.tf
@@ -1,0 +1,10 @@
+resource "aws_sns_topic" "server_start" {
+  name = "start"
+}
+
+# Example subscription:
+# resource "aws_sns_topic_subscription" "server_start_subscription" {
+#   topic_arn = aws_sns_topic.server_start.arn
+#   protocol = "sms"
+#   endpoint = "+16125555555"
+# }


### PR DESCRIPTION
Use AWS SNS to send notifications when the server is started.
- Create a new SNS topic (with example subscription) for server "start" messages
- Refactor `lambda/handlers.js` a bit to use async/await, send SNS message if one is provided via environment variable
- DRY up copy/pasted Lambda and API route infrastructure into a `route/` module