### PR TITLE
Maintenance, Bump AWS Provider Version

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -8,6 +8,7 @@ resource "aws_instance" "minecraft" {
   ami = "ami-068663a3c619dd892"
   key_name = "minecraft"
   security_groups = [ aws_security_group.minecraft.name ]
+  disable_api_termination = true
 }
 output "server_ip" { value = aws_instance.minecraft.public_ip }
 

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -1,16 +1,12 @@
-# Going with a c5.large instance type
-#  - 2 compute optimized vCPUs (single core turbo frequency of up to 3.5 GHz)
-#  - 4GB RAM
-#  - $0.085 per Hour
 resource "aws_instance" "minecraft" {
-  instance_type = "c5.large"
+  # TODO: choose a more optimal instance
+  instance_type = "c5d.large"
   # Ubuntu Server 20.04 LTS (HVM), SSD Volume Type
   ami = "ami-068663a3c619dd892"
   key_name = "minecraft"
   security_groups = [ aws_security_group.minecraft.name ]
   disable_api_termination = true
 }
-output "server_ip" { value = aws_instance.minecraft.public_ip }
 
 resource "aws_security_group" "minecraft" {
   name = "minecraft"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.68"
+  version = "~> 3.8"
   profile = "default"
   region = "us-east-1"
 }


### PR DESCRIPTION
Just a few things that have popped up over the past couple months:
- New  Terraform AWS provider, v3.8
- Disable API termination so instance isn't accidentally deleted
- Update the instance type to match my current configuration, with a note to someday circle back and choose something more optimal