### PR TITLE
Upgrade EC2 Instance from `c5d.large` to `c6i.large`

### DIFF
--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -7,7 +7,7 @@ resource "aws_cloudwatch_metric_alarm" "inactivity" {
   statistic = "Average"
   threshold = 2
   period = 300
-  treat_missing_data = "notBreaching"
+  treat_missing_data = "breaching"
 
   dimensions = {
     InstanceId = aws_instance.minecraft.id

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -1,11 +1,14 @@
 resource "aws_instance" "minecraft" {
-  # TODO: choose a more optimal instance
-  instance_type = "c5d.large"
+  instance_type = "c6i.large"
   # Ubuntu Server 20.04 LTS (HVM), SSD Volume Type
   ami = "ami-068663a3c619dd892"
   key_name = "minecraft"
   security_groups = [ aws_security_group.minecraft.name ]
   disable_api_termination = true
+
+  tags = {
+    Name = "Minecraft"
+  }
 }
 
 resource "aws_security_group" "minecraft" {


### PR DESCRIPTION
This `c5d.large` -> `c6i.large` instance type change accomplishes a couple things:
- We've never actually made use of the SSD storage from the `c5d.large`, so that's been a waste of money.
- `c6i` is "Up to 15% better compute price performance over C5 instances"

I also took the opportunity to add a name tag to the EC2 instance and commit a Cloudwatch Alarm tweak regarding missing monitor data.